### PR TITLE
handle spaces in dataset names

### DIFF
--- a/lib/zfstools/dataset.rb
+++ b/lib/zfstools/dataset.rb
@@ -28,7 +28,7 @@ module Zfs
       puts cmd if $debug
       IO.popen cmd do |io|
         io.readlines.each do |line|
-          values = line.split
+          values = line.split("\t")
           name = values.shift
           dataset_properties = {}
           properties.each_with_index do |property_name, i|

--- a/lib/zfstools/snapshot.rb
+++ b/lib/zfstools/snapshot.rb
@@ -9,7 +9,7 @@ module Zfs
 
     def used
       if @used.nil? or @@stale_snapshot_size
-        cmd = "zfs get -Hp -o value used #{@name}"
+        cmd = "zfs get -Hp -o value used \"#{@name}\""
         puts cmd if $debug
         @used = %x[#{cmd}].to_i
       end
@@ -30,12 +30,12 @@ module Zfs
       flags << "-d 1" if dataset and !options['recursive']
       flags << "-r" if options['recursive']
       cmd = "zfs list #{flags.join(" ")} -H -t snapshot -o name,used -S name"
-      cmd += " #{dataset}" if dataset
+      cmd += " \"#{dataset}\"" if dataset
       puts cmd if $debug
       IO.popen cmd do |io|
         io.readlines.each do |line|
           line.chomp!
-          snapshot_name,used = line.split(' ')
+          snapshot_name,used = line.split("\t")
           snapshots << self.new(snapshot_name, used.to_i)
         end
       end
@@ -46,7 +46,7 @@ module Zfs
     def self.create(snapshot, options = {})
       flags=[]
       flags << "-r" if options['recursive']
-      cmd = "zfs snapshot #{flags.join(" ")} #{snapshot}"
+      cmd = "zfs snapshot #{flags.join(" ")} \"#{snapshot}\""
 
       if options['db']
         case options['db']
@@ -79,7 +79,7 @@ module Zfs
       # Default to deferred snapshot destroying
       flags=["-d"]
       flags << "-r" if options['recursive']
-      cmd = "zfs destroy #{flags.join(" ")} #{@name}"
+      cmd = "zfs destroy #{flags.join(" ")} \"#{@name}\""
       puts cmd if $debug
       system(cmd) unless $dry_run
     end


### PR DESCRIPTION
Firstly, let me say thanks for this very useful tool, I've used it on a bunch of machines, and it's made snapshot maintenance a breeze!

The only problem I've had is that one of my filesystems has datasets with spaces in their names, so I had to modify a couple files to add quotes and split on tabs:
- where `system` is called, make sure dataset/snapshot names are quoted
- where zfs list is called, make sure the output is split on tabs since
  we use the -H flag which forces tabs as delimiters to the fields

-Caleb
