### PR TITLE
updated zfstools.rb to honor auto-snapshot

### DIFF
--- a/lib/zfstools.rb
+++ b/lib/zfstools.rb
@@ -134,11 +134,11 @@ def find_eligible_datasets(interval, pool)
     'included' => [],
     'excluded' => [],
   }
-
-  # Gather the datasets given the override property
-  filter_datasets datasets, included_excluded_datasets, "#{snapshot_property}:#{interval}"
+  
   # Gather all of the datasets without an override
   filter_datasets datasets, included_excluded_datasets, snapshot_property
+  # Gather the datasets given the override property
+  filter_datasets datasets, included_excluded_datasets, "#{snapshot_property}:#{interval}"
 
   ### Determine which datasets can be snapshotted recursively and which not
   datasets = find_recursive_datasets included_excluded_datasets


### PR DESCRIPTION
if filter_dataset is first called with "#{snapshot_property}:#{interval}" the dataset will already be written into included_excluded_datasets[included] and the call to filter_dataset with only snapshot_property will have no effect, therefore the option com.sun:auto-snapshot is completely ignored.
Changing both lines does the trick for me.