### PR TITLE
Accept more truthy values for dataset properties

### DIFF
--- a/lib/zfstools.rb
+++ b/lib/zfstools.rb
@@ -115,7 +115,7 @@ def filter_datasets(datasets, included_excluded_datasets, property)
     # Exclude unmounted datasets.
     if (dataset.properties['mounted'] == "yes" or
         dataset.properties['type'] == "volume") and
-      ["true","mysql","postgresql"].include? value
+      ["true","on","yes","mysql","postgresql"].include? value
       included_excluded_datasets['included'] << dataset
     elsif value
       included_excluded_datasets['excluded'] << dataset


### PR DESCRIPTION
Accept more truthy value for the `com.sun:auto-snapshot` property.

This may differ from the OpenSolaris implementation, but:

- it seems the canonical OpenZFS value for boolean true is `on`.
- it might save people like me time scratching their head in the future why their filesystems are not snapshotting.